### PR TITLE
chore: sync profile repo inventory to current dotfiles dirs

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,105 +1,108 @@
 # p6m7g8 Dotfiles Repositories
 
-## Repositories
+## Organization
+- `p6m7g8-dotfiles/.github`: Organization community health files
+- `p6m7g8-dotfiles/dotgithub`: GitHub defaults and organization templates
+- `p6m7g8-dotfiles/gh-parallel`: Parallel GitHub CLI helpers
 
-- `p6m7g8-dotfiles/.github`
-- `p6m7g8-dotfiles/dotgithub`
-- `p6m7g8-dotfiles/gh-parallel`
-- `p6m7g8-dotfiles/p61password`
-- `p6m7g8-dotfiles/p6aws`
-- `p6m7g8-dotfiles/p6awscdk`
-- `p6m7g8-dotfiles/p6common`
-- `p6m7g8-dotfiles/p6df`
-- `p6m7g8-dotfiles/p6df-1password`
-- `p6m7g8-dotfiles/p6df-R`
-- `p6m7g8-dotfiles/p6df-akuity`
-- `p6m7g8-dotfiles/p6df-alfred`
-- `p6m7g8-dotfiles/p6df-argocd`
-- `p6m7g8-dotfiles/p6df-aws`
-- `p6m7g8-dotfiles/p6df-awscdk`
-- `p6m7g8-dotfiles/p6df-awssam`
-- `p6m7g8-dotfiles/p6df-azure`
-- `p6m7g8-dotfiles/p6df-bash`
-- `p6m7g8-dotfiles/p6df-c`
-- `p6m7g8-dotfiles/p6df-cdk8s`
-- `p6m7g8-dotfiles/p6df-claudecode`
-- `p6m7g8-dotfiles/p6df-cloudflare`
-- `p6m7g8-dotfiles/p6df-cloudsmith`
-- `p6m7g8-dotfiles/p6df-confluence`
-- `p6m7g8-dotfiles/p6df-copilot`
-- `p6m7g8-dotfiles/p6df-core`
-- `p6m7g8-dotfiles/p6df-cucumber`
-- `p6m7g8-dotfiles/p6df-darwin`
-- `p6m7g8-dotfiles/p6df-databricks`
-- `p6m7g8-dotfiles/p6df-datadog`
-- `p6m7g8-dotfiles/p6df-dbt`
-- `p6m7g8-dotfiles/p6df-docker`
-- `p6m7g8-dotfiles/p6df-eslint`
-- `p6m7g8-dotfiles/p6df-figma`
-- `p6m7g8-dotfiles/p6df-gcp`
-- `p6m7g8-dotfiles/p6df-gemini`
-- `p6m7g8-dotfiles/p6df-git`
-- `p6m7g8-dotfiles/p6df-github`
-- `p6m7g8-dotfiles/p6df-go`
-- `p6m7g8-dotfiles/p6df-granola`
-- `p6m7g8-dotfiles/p6df-graphql`
-- `p6m7g8-dotfiles/p6df-helm`
-- `p6m7g8-dotfiles/p6df-heroku`
-- `p6m7g8-dotfiles/p6df-homebrew`
-- `p6m7g8-dotfiles/p6df-huggingface`
-- `p6m7g8-dotfiles/p6df-irc`
-- `p6m7g8-dotfiles/p6df-java`
-- `p6m7g8-dotfiles/p6df-jenkins`
-- `p6m7g8-dotfiles/p6df-jira`
-- `p6m7g8-dotfiles/p6df-js`
-- `p6m7g8-dotfiles/p6df-julia`
-- `p6m7g8-dotfiles/p6df-jupyter`
-- `p6m7g8-dotfiles/p6df-kubernetes`
-- `p6m7g8-dotfiles/p6df-launchdarkly`
-- `p6m7g8-dotfiles/p6df-linkedin`
-- `p6m7g8-dotfiles/p6df-lua`
-- `p6m7g8-dotfiles/p6df-macosx`
-- `p6m7g8-dotfiles/p6df-mysql`
-- `p6m7g8-dotfiles/p6df-nmap`
-- `p6m7g8-dotfiles/p6df-oci`
-- `p6m7g8-dotfiles/p6df-okta`
-- `p6m7g8-dotfiles/p6df-openai`
-- `p6m7g8-dotfiles/p6df-oracle`
-- `p6m7g8-dotfiles/p6df-pagerduty`
-- `p6m7g8-dotfiles/p6df-perl`
-- `p6m7g8-dotfiles/p6df-pgsql`
-- `p6m7g8-dotfiles/p6df-playwright`
-- `p6m7g8-dotfiles/p6df-proxy`
-- `p6m7g8-dotfiles/p6df-python`
-- `p6m7g8-dotfiles/p6df-rails`
-- `p6m7g8-dotfiles/p6df-redis`
-- `p6m7g8-dotfiles/p6df-rippling`
-- `p6m7g8-dotfiles/p6df-ruby`
-- `p6m7g8-dotfiles/p6df-rust`
-- `p6m7g8-dotfiles/p6df-scala`
-- `p6m7g8-dotfiles/p6df-shell`
-- `p6m7g8-dotfiles/p6df-slack`
-- `p6m7g8-dotfiles/p6df-snowflake`
-- `p6m7g8-dotfiles/p6df-solidity`
-- `p6m7g8-dotfiles/p6df-sqlite`
-- `p6m7g8-dotfiles/p6df-sqlserver`
-- `p6m7g8-dotfiles/p6df-storybook`
-- `p6m7g8-dotfiles/p6df-sudo`
-- `p6m7g8-dotfiles/p6df-superset`
-- `p6m7g8-dotfiles/p6df-teleport`
-- `p6m7g8-dotfiles/p6df-terraform`
-- `p6m7g8-dotfiles/p6df-tmux`
-- `p6m7g8-dotfiles/p6df-vim`
-- `p6m7g8-dotfiles/p6df-vscode`
-- `p6m7g8-dotfiles/p6df-zoom`
-- `p6m7g8-dotfiles/p6df-zsh`
-- `p6m7g8-dotfiles/p6git`
-- `p6m7g8-dotfiles/p6github`
-- `p6m7g8-dotfiles/p6helm`
-- `p6m7g8-dotfiles/p6jenkins`
-- `p6m7g8-dotfiles/p6kubernetes`
-- `p6m7g8-dotfiles/p6macosx`
-- `p6m7g8-dotfiles/p6perl`
-- `p6m7g8-dotfiles/p6pgsql`
-- `p6m7g8-dotfiles/p6python`
-- `p6m7g8-dotfiles/p6sqlite`
+## p6 Core
+- `p6m7g8-dotfiles/p61password`: 1Password helpers
+- `p6m7g8-dotfiles/p6aws`: AWS shell tooling
+- `p6m7g8-dotfiles/p6awscdk`: AWS CDK helpers
+- `p6m7g8-dotfiles/p6common`: Shared shell utilities and common functions
+- `p6m7g8-dotfiles/p6df`: Base p6df dotfiles framework
+- `p6m7g8-dotfiles/p6git`: Git helpers and workflows
+- `p6m7g8-dotfiles/p6github`: GitHub-specific tooling and aliases
+- `p6m7g8-dotfiles/p6helm`: Helm helpers
+- `p6m7g8-dotfiles/p6jenkins`: Jenkins helpers
+- `p6m7g8-dotfiles/p6kubernetes`: Kubernetes helpers
+- `p6m7g8-dotfiles/p6macosx`: macOS helpers
+- `p6m7g8-dotfiles/p6perl`: Perl helpers
+- `p6m7g8-dotfiles/p6pgsql`: PostgreSQL helpers
+- `p6m7g8-dotfiles/p6python`: Python helpers
+- `p6m7g8-dotfiles/p6sqlite`: SQLite helpers
+
+## p6df Plugins
+- `p6m7g8-dotfiles/p6df-1password`: p6df plugin for 1password
+- `p6m7g8-dotfiles/p6df-R`: p6df plugin for R
+- `p6m7g8-dotfiles/p6df-akuity`: p6df plugin for akuity
+- `p6m7g8-dotfiles/p6df-alfred`: p6df plugin for alfred
+- `p6m7g8-dotfiles/p6df-argocd`: p6df plugin for argocd
+- `p6m7g8-dotfiles/p6df-aws`: p6df plugin for AWS
+- `p6m7g8-dotfiles/p6df-awscdk`: p6df plugin for awscdk
+- `p6m7g8-dotfiles/p6df-awssam`: p6df plugin for awssam
+- `p6m7g8-dotfiles/p6df-azure`: p6df plugin for azure
+- `p6m7g8-dotfiles/p6df-bash`: p6df plugin for bash
+- `p6m7g8-dotfiles/p6df-c`: p6df plugin for C
+- `p6m7g8-dotfiles/p6df-cdk8s`: p6df plugin for cdk8s
+- `p6m7g8-dotfiles/p6df-claudecode`: p6df plugin for claudecode
+- `p6m7g8-dotfiles/p6df-cloudflare`: p6df plugin for cloudflare
+- `p6m7g8-dotfiles/p6df-cloudsmith`: p6df plugin for cloudsmith
+- `p6m7g8-dotfiles/p6df-confluence`: p6df plugin for confluence
+- `p6m7g8-dotfiles/p6df-copilot`: p6df plugin for copilot
+- `p6m7g8-dotfiles/p6df-core`: p6df plugin for core
+- `p6m7g8-dotfiles/p6df-cucumber`: p6df plugin for cucumber
+- `p6m7g8-dotfiles/p6df-darwin`: p6df plugin for darwin
+- `p6m7g8-dotfiles/p6df-databricks`: p6df plugin for databricks
+- `p6m7g8-dotfiles/p6df-datadog`: p6df plugin for datadog
+- `p6m7g8-dotfiles/p6df-dbt`: p6df plugin for dbt
+- `p6m7g8-dotfiles/p6df-docker`: p6df plugin for docker
+- `p6m7g8-dotfiles/p6df-eslint`: p6df plugin for eslint
+- `p6m7g8-dotfiles/p6df-figma`: p6df plugin for figma
+- `p6m7g8-dotfiles/p6df-gcp`: p6df plugin for GCP
+- `p6m7g8-dotfiles/p6df-gemini`: p6df plugin for gemini
+- `p6m7g8-dotfiles/p6df-git`: p6df plugin for git
+- `p6m7g8-dotfiles/p6df-github`: p6df plugin for github
+- `p6m7g8-dotfiles/p6df-go`: p6df plugin for Go
+- `p6m7g8-dotfiles/p6df-granola`: p6df plugin for granola
+- `p6m7g8-dotfiles/p6df-graphql`: p6df plugin for graphql
+- `p6m7g8-dotfiles/p6df-helm`: p6df plugin for helm
+- `p6m7g8-dotfiles/p6df-heroku`: p6df plugin for heroku
+- `p6m7g8-dotfiles/p6df-homebrew`: p6df plugin for homebrew
+- `p6m7g8-dotfiles/p6df-huggingface`: p6df plugin for huggingface
+- `p6m7g8-dotfiles/p6df-irc`: p6df plugin for IRC
+- `p6m7g8-dotfiles/p6df-java`: p6df plugin for java
+- `p6m7g8-dotfiles/p6df-jenkins`: p6df plugin for jenkins
+- `p6m7g8-dotfiles/p6df-jira`: p6df plugin for jira
+- `p6m7g8-dotfiles/p6df-js`: p6df plugin for JavaScript
+- `p6m7g8-dotfiles/p6df-julia`: p6df plugin for julia
+- `p6m7g8-dotfiles/p6df-jupyter`: p6df plugin for jupyter
+- `p6m7g8-dotfiles/p6df-kubernetes`: p6df plugin for kubernetes
+- `p6m7g8-dotfiles/p6df-launchdarkly`: p6df plugin for launchdarkly
+- `p6m7g8-dotfiles/p6df-linkedin`: p6df plugin for linkedin
+- `p6m7g8-dotfiles/p6df-lua`: p6df plugin for lua
+- `p6m7g8-dotfiles/p6df-macosx`: p6df plugin for macosx
+- `p6m7g8-dotfiles/p6df-mysql`: p6df plugin for mysql
+- `p6m7g8-dotfiles/p6df-nmap`: p6df plugin for nmap
+- `p6m7g8-dotfiles/p6df-oci`: p6df plugin for OCI
+- `p6m7g8-dotfiles/p6df-okta`: p6df plugin for okta
+- `p6m7g8-dotfiles/p6df-openai`: p6df plugin for openai
+- `p6m7g8-dotfiles/p6df-oracle`: p6df plugin for oracle
+- `p6m7g8-dotfiles/p6df-pagerduty`: p6df plugin for pagerduty
+- `p6m7g8-dotfiles/p6df-perl`: p6df plugin for perl
+- `p6m7g8-dotfiles/p6df-pgsql`: p6df plugin for pgsql
+- `p6m7g8-dotfiles/p6df-playwright`: p6df plugin for playwright
+- `p6m7g8-dotfiles/p6df-proxy`: p6df plugin for proxy
+- `p6m7g8-dotfiles/p6df-python`: p6df plugin for python
+- `p6m7g8-dotfiles/p6df-rails`: p6df plugin for rails
+- `p6m7g8-dotfiles/p6df-redis`: p6df plugin for redis
+- `p6m7g8-dotfiles/p6df-rippling`: p6df plugin for rippling
+- `p6m7g8-dotfiles/p6df-ruby`: p6df plugin for ruby
+- `p6m7g8-dotfiles/p6df-rust`: p6df plugin for rust
+- `p6m7g8-dotfiles/p6df-scala`: p6df plugin for scala
+- `p6m7g8-dotfiles/p6df-shell`: p6df plugin for shell
+- `p6m7g8-dotfiles/p6df-slack`: p6df plugin for slack
+- `p6m7g8-dotfiles/p6df-snowflake`: p6df plugin for snowflake
+- `p6m7g8-dotfiles/p6df-solidity`: p6df plugin for solidity
+- `p6m7g8-dotfiles/p6df-sqlite`: p6df plugin for sqlite
+- `p6m7g8-dotfiles/p6df-sqlserver`: p6df plugin for sqlserver
+- `p6m7g8-dotfiles/p6df-storybook`: p6df plugin for storybook
+- `p6m7g8-dotfiles/p6df-sudo`: p6df plugin for sudo
+- `p6m7g8-dotfiles/p6df-superset`: p6df plugin for superset
+- `p6m7g8-dotfiles/p6df-teleport`: p6df plugin for teleport
+- `p6m7g8-dotfiles/p6df-terraform`: p6df plugin for terraform
+- `p6m7g8-dotfiles/p6df-tmux`: p6df plugin for tmux
+- `p6m7g8-dotfiles/p6df-vim`: p6df plugin for vim
+- `p6m7g8-dotfiles/p6df-vscode`: p6df plugin for vscode
+- `p6m7g8-dotfiles/p6df-zoom`: p6df plugin for zoom
+- `p6m7g8-dotfiles/p6df-zsh`: p6df plugin for zsh

--- a/profile/README.md
+++ b/profile/README.md
@@ -24,94 +24,100 @@
 
 ## p6df Plugins
 
-### A-E Plugins
-- `p6m7g8-dotfiles/p6df-1password`: p6df plugin for 1password
+### AI & LLM Tooling
+- `p6m7g8-dotfiles/p6df-claudecode`: p6df plugin for claudecode
+- `p6m7g8-dotfiles/p6df-copilot`: p6df plugin for copilot
+- `p6m7g8-dotfiles/p6df-gemini`: p6df plugin for gemini
+- `p6m7g8-dotfiles/p6df-granola`: p6df plugin for granola
+- `p6m7g8-dotfiles/p6df-huggingface`: p6df plugin for huggingface
+- `p6m7g8-dotfiles/p6df-openai`: p6df plugin for openai
+
+### Cloud & Infrastructure
 - `p6m7g8-dotfiles/p6df-akuity`: p6df plugin for akuity
-- `p6m7g8-dotfiles/p6df-alfred`: p6df plugin for alfred
 - `p6m7g8-dotfiles/p6df-argocd`: p6df plugin for argocd
 - `p6m7g8-dotfiles/p6df-aws`: p6df plugin for AWS
 - `p6m7g8-dotfiles/p6df-awscdk`: p6df plugin for awscdk
 - `p6m7g8-dotfiles/p6df-awssam`: p6df plugin for awssam
 - `p6m7g8-dotfiles/p6df-azure`: p6df plugin for azure
-- `p6m7g8-dotfiles/p6df-bash`: p6df plugin for bash
-- `p6m7g8-dotfiles/p6df-c`: p6df plugin for C
 - `p6m7g8-dotfiles/p6df-cdk8s`: p6df plugin for cdk8s
-- `p6m7g8-dotfiles/p6df-claudecode`: p6df plugin for claudecode
 - `p6m7g8-dotfiles/p6df-cloudflare`: p6df plugin for cloudflare
 - `p6m7g8-dotfiles/p6df-cloudsmith`: p6df plugin for cloudsmith
-- `p6m7g8-dotfiles/p6df-confluence`: p6df plugin for confluence
-- `p6m7g8-dotfiles/p6df-copilot`: p6df plugin for copilot
-- `p6m7g8-dotfiles/p6df-core`: p6df plugin for core
-- `p6m7g8-dotfiles/p6df-cucumber`: p6df plugin for cucumber
-- `p6m7g8-dotfiles/p6df-darwin`: p6df plugin for darwin
-- `p6m7g8-dotfiles/p6df-databricks`: p6df plugin for databricks
 - `p6m7g8-dotfiles/p6df-datadog`: p6df plugin for datadog
-- `p6m7g8-dotfiles/p6df-dbt`: p6df plugin for dbt
-- `p6m7g8-dotfiles/p6df-docker`: p6df plugin for docker
-- `p6m7g8-dotfiles/p6df-eslint`: p6df plugin for eslint
-
-### F-L Plugins
-- `p6m7g8-dotfiles/p6df-figma`: p6df plugin for figma
 - `p6m7g8-dotfiles/p6df-gcp`: p6df plugin for GCP
-- `p6m7g8-dotfiles/p6df-gemini`: p6df plugin for gemini
-- `p6m7g8-dotfiles/p6df-git`: p6df plugin for git
-- `p6m7g8-dotfiles/p6df-github`: p6df plugin for github
-- `p6m7g8-dotfiles/p6df-go`: p6df plugin for Go
-- `p6m7g8-dotfiles/p6df-granola`: p6df plugin for granola
-- `p6m7g8-dotfiles/p6df-graphql`: p6df plugin for graphql
 - `p6m7g8-dotfiles/p6df-helm`: p6df plugin for helm
 - `p6m7g8-dotfiles/p6df-heroku`: p6df plugin for heroku
-- `p6m7g8-dotfiles/p6df-homebrew`: p6df plugin for homebrew
-- `p6m7g8-dotfiles/p6df-huggingface`: p6df plugin for huggingface
-- `p6m7g8-dotfiles/p6df-irc`: p6df plugin for IRC
-- `p6m7g8-dotfiles/p6df-java`: p6df plugin for java
-- `p6m7g8-dotfiles/p6df-jenkins`: p6df plugin for jenkins
-- `p6m7g8-dotfiles/p6df-jira`: p6df plugin for jira
-- `p6m7g8-dotfiles/p6df-js`: p6df plugin for JavaScript
-- `p6m7g8-dotfiles/p6df-julia`: p6df plugin for julia
-- `p6m7g8-dotfiles/p6df-jupyter`: p6df plugin for jupyter
 - `p6m7g8-dotfiles/p6df-kubernetes`: p6df plugin for kubernetes
 - `p6m7g8-dotfiles/p6df-launchdarkly`: p6df plugin for launchdarkly
-- `p6m7g8-dotfiles/p6df-linkedin`: p6df plugin for linkedin
-- `p6m7g8-dotfiles/p6df-lua`: p6df plugin for lua
-
-### M-R Plugins
-- `p6m7g8-dotfiles/p6df-R`: p6df plugin for R
-- `p6m7g8-dotfiles/p6df-macosx`: p6df plugin for macosx
-- `p6m7g8-dotfiles/p6df-mysql`: p6df plugin for mysql
-- `p6m7g8-dotfiles/p6df-nmap`: p6df plugin for nmap
 - `p6m7g8-dotfiles/p6df-oci`: p6df plugin for OCI
-- `p6m7g8-dotfiles/p6df-okta`: p6df plugin for okta
-- `p6m7g8-dotfiles/p6df-openai`: p6df plugin for openai
-- `p6m7g8-dotfiles/p6df-oracle`: p6df plugin for oracle
 - `p6m7g8-dotfiles/p6df-pagerduty`: p6df plugin for pagerduty
-- `p6m7g8-dotfiles/p6df-perl`: p6df plugin for perl
-- `p6m7g8-dotfiles/p6df-pgsql`: p6df plugin for pgsql
-- `p6m7g8-dotfiles/p6df-playwright`: p6df plugin for playwright
-- `p6m7g8-dotfiles/p6df-proxy`: p6df plugin for proxy
-- `p6m7g8-dotfiles/p6df-python`: p6df plugin for python
-- `p6m7g8-dotfiles/p6df-rails`: p6df plugin for rails
-- `p6m7g8-dotfiles/p6df-redis`: p6df plugin for redis
-- `p6m7g8-dotfiles/p6df-rippling`: p6df plugin for rippling
-- `p6m7g8-dotfiles/p6df-ruby`: p6df plugin for ruby
-- `p6m7g8-dotfiles/p6df-rust`: p6df plugin for rust
-
-### S-Z Plugins
-- `p6m7g8-dotfiles/p6df-scala`: p6df plugin for scala
-- `p6m7g8-dotfiles/p6df-shell`: p6df plugin for shell
-- `p6m7g8-dotfiles/p6df-slack`: p6df plugin for slack
-- `p6m7g8-dotfiles/p6df-snowflake`: p6df plugin for snowflake
-- `p6m7g8-dotfiles/p6df-solidity`: p6df plugin for solidity
-- `p6m7g8-dotfiles/p6df-sqlite`: p6df plugin for sqlite
-- `p6m7g8-dotfiles/p6df-sqlserver`: p6df plugin for sqlserver
-- `p6m7g8-dotfiles/p6df-storybook`: p6df plugin for storybook
-- `p6m7g8-dotfiles/p6df-sudo`: p6df plugin for sudo
-- `p6m7g8-dotfiles/p6df-superset`: p6df plugin for superset
 - `p6m7g8-dotfiles/p6df-teleport`: p6df plugin for teleport
 - `p6m7g8-dotfiles/p6df-terraform`: p6df plugin for terraform
+
+### Data & Databases
+- `p6m7g8-dotfiles/p6df-databricks`: p6df plugin for databricks
+- `p6m7g8-dotfiles/p6df-dbt`: p6df plugin for dbt
+- `p6m7g8-dotfiles/p6df-graphql`: p6df plugin for graphql
+- `p6m7g8-dotfiles/p6df-jupyter`: p6df plugin for jupyter
+- `p6m7g8-dotfiles/p6df-mysql`: p6df plugin for mysql
+- `p6m7g8-dotfiles/p6df-oracle`: p6df plugin for oracle
+- `p6m7g8-dotfiles/p6df-pgsql`: p6df plugin for pgsql
+- `p6m7g8-dotfiles/p6df-redis`: p6df plugin for redis
+- `p6m7g8-dotfiles/p6df-snowflake`: p6df plugin for snowflake
+- `p6m7g8-dotfiles/p6df-sqlite`: p6df plugin for sqlite
+- `p6m7g8-dotfiles/p6df-sqlserver`: p6df plugin for sqlserver
+- `p6m7g8-dotfiles/p6df-superset`: p6df plugin for superset
+
+### Developer Tooling
+- `p6m7g8-dotfiles/p6df-cucumber`: p6df plugin for cucumber
+- `p6m7g8-dotfiles/p6df-docker`: p6df plugin for docker
+- `p6m7g8-dotfiles/p6df-eslint`: p6df plugin for eslint
+- `p6m7g8-dotfiles/p6df-git`: p6df plugin for git
+- `p6m7g8-dotfiles/p6df-github`: p6df plugin for github
+- `p6m7g8-dotfiles/p6df-homebrew`: p6df plugin for homebrew
+- `p6m7g8-dotfiles/p6df-jenkins`: p6df plugin for jenkins
+- `p6m7g8-dotfiles/p6df-nmap`: p6df plugin for nmap
+- `p6m7g8-dotfiles/p6df-playwright`: p6df plugin for playwright
+- `p6m7g8-dotfiles/p6df-proxy`: p6df plugin for proxy
+- `p6m7g8-dotfiles/p6df-storybook`: p6df plugin for storybook
+- `p6m7g8-dotfiles/p6df-vscode`: p6df plugin for vscode
+
+### Programming Languages
+- `p6m7g8-dotfiles/p6df-R`: p6df plugin for R
+- `p6m7g8-dotfiles/p6df-bash`: p6df plugin for bash
+- `p6m7g8-dotfiles/p6df-c`: p6df plugin for C
+- `p6m7g8-dotfiles/p6df-go`: p6df plugin for Go
+- `p6m7g8-dotfiles/p6df-java`: p6df plugin for java
+- `p6m7g8-dotfiles/p6df-js`: p6df plugin for JavaScript
+- `p6m7g8-dotfiles/p6df-julia`: p6df plugin for julia
+- `p6m7g8-dotfiles/p6df-lua`: p6df plugin for lua
+- `p6m7g8-dotfiles/p6df-perl`: p6df plugin for perl
+- `p6m7g8-dotfiles/p6df-python`: p6df plugin for python
+- `p6m7g8-dotfiles/p6df-rails`: p6df plugin for rails
+- `p6m7g8-dotfiles/p6df-ruby`: p6df plugin for ruby
+- `p6m7g8-dotfiles/p6df-rust`: p6df plugin for rust
+- `p6m7g8-dotfiles/p6df-scala`: p6df plugin for scala
+- `p6m7g8-dotfiles/p6df-solidity`: p6df plugin for solidity
+
+### Collaboration & Productivity
+- `p6m7g8-dotfiles/p6df-1password`: p6df plugin for 1password
+- `p6m7g8-dotfiles/p6df-alfred`: p6df plugin for alfred
+- `p6m7g8-dotfiles/p6df-confluence`: p6df plugin for confluence
+- `p6m7g8-dotfiles/p6df-figma`: p6df plugin for figma
+- `p6m7g8-dotfiles/p6df-irc`: p6df plugin for IRC
+- `p6m7g8-dotfiles/p6df-jira`: p6df plugin for jira
+- `p6m7g8-dotfiles/p6df-linkedin`: p6df plugin for linkedin
+- `p6m7g8-dotfiles/p6df-okta`: p6df plugin for okta
+- `p6m7g8-dotfiles/p6df-rippling`: p6df plugin for rippling
+- `p6m7g8-dotfiles/p6df-slack`: p6df plugin for slack
+- `p6m7g8-dotfiles/p6df-zoom`: p6df plugin for zoom
+
+### System & Shell
+- `p6m7g8-dotfiles/p6df-core`: p6df plugin for core
+- `p6m7g8-dotfiles/p6df-darwin`: p6df plugin for darwin
+- `p6m7g8-dotfiles/p6df-macosx`: p6df plugin for macosx
+- `p6m7g8-dotfiles/p6df-shell`: p6df plugin for shell
+- `p6m7g8-dotfiles/p6df-sudo`: p6df plugin for sudo
 - `p6m7g8-dotfiles/p6df-tmux`: p6df plugin for tmux
 - `p6m7g8-dotfiles/p6df-vim`: p6df plugin for vim
-- `p6m7g8-dotfiles/p6df-vscode`: p6df plugin for vscode
-- `p6m7g8-dotfiles/p6df-zoom`: p6df plugin for zoom
 - `p6m7g8-dotfiles/p6df-zsh`: p6df plugin for zsh
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -82,7 +82,6 @@
 - `p6m7g8-dotfiles/p6df-vscode`: p6df plugin for vscode
 
 ### Programming Languages
-- `p6m7g8-dotfiles/p6df-R`: p6df plugin for R
 - `p6m7g8-dotfiles/p6df-bash`: p6df plugin for bash
 - `p6m7g8-dotfiles/p6df-c`: p6df plugin for C
 - `p6m7g8-dotfiles/p6df-go`: p6df plugin for Go
@@ -92,6 +91,7 @@
 - `p6m7g8-dotfiles/p6df-lua`: p6df plugin for lua
 - `p6m7g8-dotfiles/p6df-perl`: p6df plugin for perl
 - `p6m7g8-dotfiles/p6df-python`: p6df plugin for python
+- `p6m7g8-dotfiles/p6df-R`: p6df plugin for R
 - `p6m7g8-dotfiles/p6df-rails`: p6df plugin for rails
 - `p6m7g8-dotfiles/p6df-ruby`: p6df plugin for ruby
 - `p6m7g8-dotfiles/p6df-rust`: p6df plugin for rust

--- a/profile/README.md
+++ b/profile/README.md
@@ -23,8 +23,9 @@
 - `p6m7g8-dotfiles/p6sqlite`: SQLite helpers
 
 ## p6df Plugins
+
+### A-E Plugins
 - `p6m7g8-dotfiles/p6df-1password`: p6df plugin for 1password
-- `p6m7g8-dotfiles/p6df-R`: p6df plugin for R
 - `p6m7g8-dotfiles/p6df-akuity`: p6df plugin for akuity
 - `p6m7g8-dotfiles/p6df-alfred`: p6df plugin for alfred
 - `p6m7g8-dotfiles/p6df-argocd`: p6df plugin for argocd
@@ -48,6 +49,8 @@
 - `p6m7g8-dotfiles/p6df-dbt`: p6df plugin for dbt
 - `p6m7g8-dotfiles/p6df-docker`: p6df plugin for docker
 - `p6m7g8-dotfiles/p6df-eslint`: p6df plugin for eslint
+
+### F-L Plugins
 - `p6m7g8-dotfiles/p6df-figma`: p6df plugin for figma
 - `p6m7g8-dotfiles/p6df-gcp`: p6df plugin for GCP
 - `p6m7g8-dotfiles/p6df-gemini`: p6df plugin for gemini
@@ -71,6 +74,9 @@
 - `p6m7g8-dotfiles/p6df-launchdarkly`: p6df plugin for launchdarkly
 - `p6m7g8-dotfiles/p6df-linkedin`: p6df plugin for linkedin
 - `p6m7g8-dotfiles/p6df-lua`: p6df plugin for lua
+
+### M-R Plugins
+- `p6m7g8-dotfiles/p6df-R`: p6df plugin for R
 - `p6m7g8-dotfiles/p6df-macosx`: p6df plugin for macosx
 - `p6m7g8-dotfiles/p6df-mysql`: p6df plugin for mysql
 - `p6m7g8-dotfiles/p6df-nmap`: p6df plugin for nmap
@@ -89,6 +95,8 @@
 - `p6m7g8-dotfiles/p6df-rippling`: p6df plugin for rippling
 - `p6m7g8-dotfiles/p6df-ruby`: p6df plugin for ruby
 - `p6m7g8-dotfiles/p6df-rust`: p6df plugin for rust
+
+### S-Z Plugins
 - `p6m7g8-dotfiles/p6df-scala`: p6df plugin for scala
 - `p6m7g8-dotfiles/p6df-shell`: p6df plugin for shell
 - `p6m7g8-dotfiles/p6df-slack`: p6df plugin for slack
@@ -106,3 +114,4 @@
 - `p6m7g8-dotfiles/p6df-vscode`: p6df plugin for vscode
 - `p6m7g8-dotfiles/p6df-zoom`: p6df plugin for zoom
 - `p6m7g8-dotfiles/p6df-zsh`: p6df plugin for zsh
+

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,12 +1,105 @@
-## Hi there 👋
+# p6m7g8 Dotfiles Repositories
 
-<!--
+## Repositories
 
-**Here are some ideas to get you started:**
-
-🙋‍♀️ A short introduction - what is your organization all about?
-🌈 Contribution guidelines - how can the community get involved?
-👩‍💻 Useful resources - where can the community find your docs? Is there anything else the community should know?
-🍿 Fun facts - what does your team eat for breakfast?
-🧙 Remember, you can do mighty things with the power of [Markdown](https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
--->
+- `p6m7g8-dotfiles/.github`
+- `p6m7g8-dotfiles/dotgithub`
+- `p6m7g8-dotfiles/gh-parallel`
+- `p6m7g8-dotfiles/p61password`
+- `p6m7g8-dotfiles/p6aws`
+- `p6m7g8-dotfiles/p6awscdk`
+- `p6m7g8-dotfiles/p6common`
+- `p6m7g8-dotfiles/p6df`
+- `p6m7g8-dotfiles/p6df-1password`
+- `p6m7g8-dotfiles/p6df-R`
+- `p6m7g8-dotfiles/p6df-akuity`
+- `p6m7g8-dotfiles/p6df-alfred`
+- `p6m7g8-dotfiles/p6df-argocd`
+- `p6m7g8-dotfiles/p6df-aws`
+- `p6m7g8-dotfiles/p6df-awscdk`
+- `p6m7g8-dotfiles/p6df-awssam`
+- `p6m7g8-dotfiles/p6df-azure`
+- `p6m7g8-dotfiles/p6df-bash`
+- `p6m7g8-dotfiles/p6df-c`
+- `p6m7g8-dotfiles/p6df-cdk8s`
+- `p6m7g8-dotfiles/p6df-claudecode`
+- `p6m7g8-dotfiles/p6df-cloudflare`
+- `p6m7g8-dotfiles/p6df-cloudsmith`
+- `p6m7g8-dotfiles/p6df-confluence`
+- `p6m7g8-dotfiles/p6df-copilot`
+- `p6m7g8-dotfiles/p6df-core`
+- `p6m7g8-dotfiles/p6df-cucumber`
+- `p6m7g8-dotfiles/p6df-darwin`
+- `p6m7g8-dotfiles/p6df-databricks`
+- `p6m7g8-dotfiles/p6df-datadog`
+- `p6m7g8-dotfiles/p6df-dbt`
+- `p6m7g8-dotfiles/p6df-docker`
+- `p6m7g8-dotfiles/p6df-eslint`
+- `p6m7g8-dotfiles/p6df-figma`
+- `p6m7g8-dotfiles/p6df-gcp`
+- `p6m7g8-dotfiles/p6df-gemini`
+- `p6m7g8-dotfiles/p6df-git`
+- `p6m7g8-dotfiles/p6df-github`
+- `p6m7g8-dotfiles/p6df-go`
+- `p6m7g8-dotfiles/p6df-granola`
+- `p6m7g8-dotfiles/p6df-graphql`
+- `p6m7g8-dotfiles/p6df-helm`
+- `p6m7g8-dotfiles/p6df-heroku`
+- `p6m7g8-dotfiles/p6df-homebrew`
+- `p6m7g8-dotfiles/p6df-huggingface`
+- `p6m7g8-dotfiles/p6df-irc`
+- `p6m7g8-dotfiles/p6df-java`
+- `p6m7g8-dotfiles/p6df-jenkins`
+- `p6m7g8-dotfiles/p6df-jira`
+- `p6m7g8-dotfiles/p6df-js`
+- `p6m7g8-dotfiles/p6df-julia`
+- `p6m7g8-dotfiles/p6df-jupyter`
+- `p6m7g8-dotfiles/p6df-kubernetes`
+- `p6m7g8-dotfiles/p6df-launchdarkly`
+- `p6m7g8-dotfiles/p6df-linkedin`
+- `p6m7g8-dotfiles/p6df-lua`
+- `p6m7g8-dotfiles/p6df-macosx`
+- `p6m7g8-dotfiles/p6df-mysql`
+- `p6m7g8-dotfiles/p6df-nmap`
+- `p6m7g8-dotfiles/p6df-oci`
+- `p6m7g8-dotfiles/p6df-okta`
+- `p6m7g8-dotfiles/p6df-openai`
+- `p6m7g8-dotfiles/p6df-oracle`
+- `p6m7g8-dotfiles/p6df-pagerduty`
+- `p6m7g8-dotfiles/p6df-perl`
+- `p6m7g8-dotfiles/p6df-pgsql`
+- `p6m7g8-dotfiles/p6df-playwright`
+- `p6m7g8-dotfiles/p6df-proxy`
+- `p6m7g8-dotfiles/p6df-python`
+- `p6m7g8-dotfiles/p6df-rails`
+- `p6m7g8-dotfiles/p6df-redis`
+- `p6m7g8-dotfiles/p6df-rippling`
+- `p6m7g8-dotfiles/p6df-ruby`
+- `p6m7g8-dotfiles/p6df-rust`
+- `p6m7g8-dotfiles/p6df-scala`
+- `p6m7g8-dotfiles/p6df-shell`
+- `p6m7g8-dotfiles/p6df-slack`
+- `p6m7g8-dotfiles/p6df-snowflake`
+- `p6m7g8-dotfiles/p6df-solidity`
+- `p6m7g8-dotfiles/p6df-sqlite`
+- `p6m7g8-dotfiles/p6df-sqlserver`
+- `p6m7g8-dotfiles/p6df-storybook`
+- `p6m7g8-dotfiles/p6df-sudo`
+- `p6m7g8-dotfiles/p6df-superset`
+- `p6m7g8-dotfiles/p6df-teleport`
+- `p6m7g8-dotfiles/p6df-terraform`
+- `p6m7g8-dotfiles/p6df-tmux`
+- `p6m7g8-dotfiles/p6df-vim`
+- `p6m7g8-dotfiles/p6df-vscode`
+- `p6m7g8-dotfiles/p6df-zoom`
+- `p6m7g8-dotfiles/p6df-zsh`
+- `p6m7g8-dotfiles/p6git`
+- `p6m7g8-dotfiles/p6github`
+- `p6m7g8-dotfiles/p6helm`
+- `p6m7g8-dotfiles/p6jenkins`
+- `p6m7g8-dotfiles/p6kubernetes`
+- `p6m7g8-dotfiles/p6macosx`
+- `p6m7g8-dotfiles/p6perl`
+- `p6m7g8-dotfiles/p6pgsql`
+- `p6m7g8-dotfiles/p6python`
+- `p6m7g8-dotfiles/p6sqlite`


### PR DESCRIPTION
## Summary
- replace placeholder profile README content
- sync listed repositories to current top-level directories in \
- keep list alphabetized and complete