### PR TITLE
docs: reorganize README by topic-based groups

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,18 +2,21 @@
 
 ## Organization
 - `p6m7g8-dotfiles/.github`: Organization community health files
-- `p6m7g8-dotfiles/dotgithub`: GitHub defaults and organization templates
 - `p6m7g8-dotfiles/gh-parallel`: Parallel GitHub CLI helpers
 
-## p6 Core
+## Framework Core
+- `p6m7g8-dotfiles/p6df`: Base p6df dotfiles framework
+- `p6m7g8-dotfiles/p6df-core`: Plugin framework core
+- `p6m7g8-dotfiles/p6common`: Shared shell utilities and common functions
+
+## p6 Libraries
 - `p6m7g8-dotfiles/p61password`: 1Password helpers
 - `p6m7g8-dotfiles/p6aws`: AWS shell tooling
 - `p6m7g8-dotfiles/p6awscdk`: AWS CDK helpers
-- `p6m7g8-dotfiles/p6common`: Shared shell utilities and common functions
-- `p6m7g8-dotfiles/p6df`: Base p6df dotfiles framework
 - `p6m7g8-dotfiles/p6git`: Git helpers and workflows
 - `p6m7g8-dotfiles/p6github`: GitHub-specific tooling and aliases
 - `p6m7g8-dotfiles/p6helm`: Helm helpers
+- `p6m7g8-dotfiles/p6huggingface`: Hugging Face helpers
 - `p6m7g8-dotfiles/p6jenkins`: Jenkins helpers
 - `p6m7g8-dotfiles/p6kubernetes`: Kubernetes helpers
 - `p6m7g8-dotfiles/p6macosx`: macOS helpers
@@ -24,119 +27,121 @@
 
 ## p6df Plugins
 
-### AI & LLM Tooling
-- `p6m7g8-dotfiles/p6df-anthropic`: p6df plugin for anthropic
-- `p6m7g8-dotfiles/p6df-chatgpt`: p6df plugin for chatgpt
-- `p6m7g8-dotfiles/p6df-claude`: p6df plugin for claude
-- `p6m7g8-dotfiles/p6df-codex`: p6df plugin for codex
-- `p6m7g8-dotfiles/p6df-copilot`: p6df plugin for copilot
-- `p6m7g8-dotfiles/p6df-gemini`: p6df plugin for gemini
-- `p6m7g8-dotfiles/p6df-granola`: p6df plugin for granola
-- `p6m7g8-dotfiles/p6df-huggingface`: p6df plugin for huggingface
-- `p6m7g8-dotfiles/p6df-openai`: p6df plugin for openai
-- `p6m7g8-dotfiles/p6df-whisper`: p6df plugin for whisper
+### AI & Generative AI
+- `p6m7g8-dotfiles/p6df-anthropic`: p6df plugin for Anthropic
+- `p6m7g8-dotfiles/p6df-chatgpt`: p6df plugin for ChatGPT
+- `p6m7g8-dotfiles/p6df-claude`: p6df plugin for Claude
+- `p6m7g8-dotfiles/p6df-claudecode`: p6df plugin for Claude Code
+- `p6m7g8-dotfiles/p6df-codex`: p6df plugin for Codex
+- `p6m7g8-dotfiles/p6df-gemini`: p6df plugin for Gemini
+- `p6m7g8-dotfiles/p6df-ghcopilot`: p6df plugin for GitHub Copilot
+- `p6m7g8-dotfiles/p6df-granola`: p6df plugin for Granola
+- `p6m7g8-dotfiles/p6df-huggingface`: p6df plugin for Hugging Face
+- `p6m7g8-dotfiles/p6df-openai`: p6df plugin for OpenAI
+- `p6m7g8-dotfiles/p6df-whisper`: p6df plugin for Whisper
 
-### Cloud & Infrastructure
-- `p6m7g8-dotfiles/p6df-akuity`: p6df plugin for akuity
-- `p6m7g8-dotfiles/p6df-argocd`: p6df plugin for argocd
+### Cloud Providers
 - `p6m7g8-dotfiles/p6df-aws`: p6df plugin for AWS
-- `p6m7g8-dotfiles/p6df-awscdk`: p6df plugin for awscdk
-- `p6m7g8-dotfiles/p6df-awssam`: p6df plugin for awssam
-- `p6m7g8-dotfiles/p6df-azure`: p6df plugin for azure
-- `p6m7g8-dotfiles/p6df-cdk8s`: p6df plugin for cdk8s
-- `p6m7g8-dotfiles/p6df-cisco`: p6df plugin for cisco
-- `p6m7g8-dotfiles/p6df-cloudflare`: p6df plugin for cloudflare
-- `p6m7g8-dotfiles/p6df-cloudsmith`: p6df plugin for cloudsmith
-- `p6m7g8-dotfiles/p6df-datadog`: p6df plugin for datadog
+- `p6m7g8-dotfiles/p6df-azure`: p6df plugin for Azure
 - `p6m7g8-dotfiles/p6df-gcp`: p6df plugin for GCP
-- `p6m7g8-dotfiles/p6df-helm`: p6df plugin for helm
-- `p6m7g8-dotfiles/p6df-heroku`: p6df plugin for heroku
-- `p6m7g8-dotfiles/p6df-kubernetes`: p6df plugin for kubernetes
-- `p6m7g8-dotfiles/p6df-launchdarkly`: p6df plugin for launchdarkly
+- `p6m7g8-dotfiles/p6df-heroku`: p6df plugin for Heroku
 - `p6m7g8-dotfiles/p6df-oci`: p6df plugin for OCI
-- `p6m7g8-dotfiles/p6df-pagerduty`: p6df plugin for pagerduty
-- `p6m7g8-dotfiles/p6df-signadot`: p6df plugin for signadot
-- `p6m7g8-dotfiles/p6df-statuspage`: p6df plugin for statuspage
-- `p6m7g8-dotfiles/p6df-teleport`: p6df plugin for teleport
-- `p6m7g8-dotfiles/p6df-terraform`: p6df plugin for terraform
 
-### Data & Databases
-- `p6m7g8-dotfiles/p6df-databricks`: p6df plugin for databricks
-- `p6m7g8-dotfiles/p6df-dbt`: p6df plugin for dbt
-- `p6m7g8-dotfiles/p6df-graphql`: p6df plugin for graphql
-- `p6m7g8-dotfiles/p6df-jupyter`: p6df plugin for jupyter
-- `p6m7g8-dotfiles/p6df-mysql`: p6df plugin for mysql
-- `p6m7g8-dotfiles/p6df-oracle`: p6df plugin for oracle
-- `p6m7g8-dotfiles/p6df-pgsql`: p6df plugin for pgsql
-- `p6m7g8-dotfiles/p6df-redis`: p6df plugin for redis
-- `p6m7g8-dotfiles/p6df-snowflake`: p6df plugin for snowflake
-- `p6m7g8-dotfiles/p6df-sqlite`: p6df plugin for sqlite
-- `p6m7g8-dotfiles/p6df-sqlserver`: p6df plugin for sqlserver
-- `p6m7g8-dotfiles/p6df-superset`: p6df plugin for superset
+### Cloud Native & DevOps
+- `p6m7g8-dotfiles/p6df-akuity`: p6df plugin for Akuity
+- `p6m7g8-dotfiles/p6df-argocd`: p6df plugin for ArgoCD
+- `p6m7g8-dotfiles/p6df-awscdk`: p6df plugin for AWS CDK
+- `p6m7g8-dotfiles/p6df-awssam`: p6df plugin for AWS SAM
+- `p6m7g8-dotfiles/p6df-cdk8s`: p6df plugin for cdk8s
+- `p6m7g8-dotfiles/p6df-datadog`: p6df plugin for Datadog
+- `p6m7g8-dotfiles/p6df-docker`: p6df plugin for Docker
+- `p6m7g8-dotfiles/p6df-helm`: p6df plugin for Helm
+- `p6m7g8-dotfiles/p6df-kubernetes`: p6df plugin for Kubernetes
+- `p6m7g8-dotfiles/p6df-launchdarkly`: p6df plugin for LaunchDarkly
+- `p6m7g8-dotfiles/p6df-terraform`: p6df plugin for Terraform
 
-### Developer Tooling
-- `p6m7g8-dotfiles/p6df-cucumber`: p6df plugin for cucumber
-- `p6m7g8-dotfiles/p6df-docker`: p6df plugin for docker
-- `p6m7g8-dotfiles/p6df-eslint`: p6df plugin for eslint
-- `p6m7g8-dotfiles/p6df-git`: p6df plugin for git
-- `p6m7g8-dotfiles/p6df-github`: p6df plugin for github
-- `p6m7g8-dotfiles/p6df-homebrew`: p6df plugin for homebrew
-- `p6m7g8-dotfiles/p6df-jenkins`: p6df plugin for jenkins
+### Security & Networking
+- `p6m7g8-dotfiles/p6df-1password`: p6df plugin for 1Password
+- `p6m7g8-dotfiles/p6df-cisco`: p6df plugin for Cisco
+- `p6m7g8-dotfiles/p6df-cloudflare`: p6df plugin for Cloudflare
+- `p6m7g8-dotfiles/p6df-cloudsmith`: p6df plugin for Cloudsmith
+- `p6m7g8-dotfiles/p6df-drata`: p6df plugin for Drata
 - `p6m7g8-dotfiles/p6df-nmap`: p6df plugin for nmap
-- `p6m7g8-dotfiles/p6df-playwright`: p6df plugin for playwright
-- `p6m7g8-dotfiles/p6df-postman`: p6df plugin for postman
+- `p6m7g8-dotfiles/p6df-okta`: p6df plugin for Okta
 - `p6m7g8-dotfiles/p6df-proxy`: p6df plugin for proxy
-- `p6m7g8-dotfiles/p6df-pusher`: p6df plugin for pusher
-- `p6m7g8-dotfiles/p6df-storybook`: p6df plugin for storybook
-- `p6m7g8-dotfiles/p6df-vscode`: p6df plugin for vscode
+- `p6m7g8-dotfiles/p6df-signadot`: p6df plugin for Signadot
+- `p6m7g8-dotfiles/p6df-teleport`: p6df plugin for Teleport
+
+### Data & Analytics
+- `p6m7g8-dotfiles/p6df-databricks`: p6df plugin for Databricks
+- `p6m7g8-dotfiles/p6df-dbt`: p6df plugin for dbt
+- `p6m7g8-dotfiles/p6df-graphql`: p6df plugin for GraphQL
+- `p6m7g8-dotfiles/p6df-jupyter`: p6df plugin for Jupyter
+- `p6m7g8-dotfiles/p6df-mysql`: p6df plugin for MySQL
+- `p6m7g8-dotfiles/p6df-oracle`: p6df plugin for Oracle
+- `p6m7g8-dotfiles/p6df-pgsql`: p6df plugin for PostgreSQL
+- `p6m7g8-dotfiles/p6df-redis`: p6df plugin for Redis
+- `p6m7g8-dotfiles/p6df-snowflake`: p6df plugin for Snowflake
+- `p6m7g8-dotfiles/p6df-sqlite`: p6df plugin for SQLite
+- `p6m7g8-dotfiles/p6df-sqlserver`: p6df plugin for SQL Server
+- `p6m7g8-dotfiles/p6df-superset`: p6df plugin for Superset
 
 ### Programming Languages
-- `p6m7g8-dotfiles/p6df-bash`: p6df plugin for bash
+- `p6m7g8-dotfiles/p6df-bash`: p6df plugin for Bash
 - `p6m7g8-dotfiles/p6df-c`: p6df plugin for C
 - `p6m7g8-dotfiles/p6df-go`: p6df plugin for Go
-- `p6m7g8-dotfiles/p6df-java`: p6df plugin for java
+- `p6m7g8-dotfiles/p6df-java`: p6df plugin for Java
 - `p6m7g8-dotfiles/p6df-js`: p6df plugin for JavaScript
-- `p6m7g8-dotfiles/p6df-julia`: p6df plugin for julia
-- `p6m7g8-dotfiles/p6df-lua`: p6df plugin for lua
-- `p6m7g8-dotfiles/p6df-perl`: p6df plugin for perl
-- `p6m7g8-dotfiles/p6df-python`: p6df plugin for python
+- `p6m7g8-dotfiles/p6df-julia`: p6df plugin for Julia
+- `p6m7g8-dotfiles/p6df-lua`: p6df plugin for Lua
+- `p6m7g8-dotfiles/p6df-perl`: p6df plugin for Perl
+- `p6m7g8-dotfiles/p6df-python`: p6df plugin for Python
 - `p6m7g8-dotfiles/p6df-R`: p6df plugin for R
-- `p6m7g8-dotfiles/p6df-rails`: p6df plugin for rails
-- `p6m7g8-dotfiles/p6df-ruby`: p6df plugin for ruby
-- `p6m7g8-dotfiles/p6df-rust`: p6df plugin for rust
-- `p6m7g8-dotfiles/p6df-scala`: p6df plugin for scala
-- `p6m7g8-dotfiles/p6df-solidity`: p6df plugin for solidity
+- `p6m7g8-dotfiles/p6df-rails`: p6df plugin for Rails
+- `p6m7g8-dotfiles/p6df-ruby`: p6df plugin for Ruby
+- `p6m7g8-dotfiles/p6df-rust`: p6df plugin for Rust
+- `p6m7g8-dotfiles/p6df-scala`: p6df plugin for Scala
+- `p6m7g8-dotfiles/p6df-solidity`: p6df plugin for Solidity
 
-### Collaboration & Productivity
-- `p6m7g8-dotfiles/p6df-1password`: p6df plugin for 1password
-- `p6m7g8-dotfiles/p6df-alfred`: p6df plugin for alfred
-- `p6m7g8-dotfiles/p6df-atlassian`: p6df plugin for atlassian
-- `p6m7g8-dotfiles/p6df-confluence`: p6df plugin for confluence
-- `p6m7g8-dotfiles/p6df-drata`: p6df plugin for drata
-- `p6m7g8-dotfiles/p6df-euc`: p6df plugin for euc
-- `p6m7g8-dotfiles/p6df-figma`: p6df plugin for figma
-- `p6m7g8-dotfiles/p6df-greenhouse`: p6df plugin for greenhouse
-- `p6m7g8-dotfiles/p6df-gws`: p6df plugin for gws
-- `p6m7g8-dotfiles/p6df-intacct`: p6df plugin for intacct
+### Developer Tooling
+- `p6m7g8-dotfiles/p6df-cucumber`: p6df plugin for Cucumber
+- `p6m7g8-dotfiles/p6df-eslint`: p6df plugin for ESLint
+- `p6m7g8-dotfiles/p6df-git`: p6df plugin for Git
+- `p6m7g8-dotfiles/p6df-github`: p6df plugin for GitHub
+- `p6m7g8-dotfiles/p6df-jenkins`: p6df plugin for Jenkins
+- `p6m7g8-dotfiles/p6df-playwright`: p6df plugin for Playwright
+- `p6m7g8-dotfiles/p6df-postman`: p6df plugin for Postman
+- `p6m7g8-dotfiles/p6df-pusher`: p6df plugin for Pusher
+- `p6m7g8-dotfiles/p6df-storybook`: p6df plugin for Storybook
+- `p6m7g8-dotfiles/p6df-vscode`: p6df plugin for VS Code
+
+### Collaboration & SaaS
+- `p6m7g8-dotfiles/p6df-alfred`: p6df plugin for Alfred
+- `p6m7g8-dotfiles/p6df-atlassian`: p6df plugin for Atlassian
+- `p6m7g8-dotfiles/p6df-confluence`: p6df plugin for Confluence
+- `p6m7g8-dotfiles/p6df-euc`: p6df plugin for EUC
+- `p6m7g8-dotfiles/p6df-figma`: p6df plugin for Figma
+- `p6m7g8-dotfiles/p6df-gws`: p6df plugin for Google Workspace
+- `p6m7g8-dotfiles/p6df-intacct`: p6df plugin for Intacct
 - `p6m7g8-dotfiles/p6df-irc`: p6df plugin for IRC
-- `p6m7g8-dotfiles/p6df-jira`: p6df plugin for jira
-- `p6m7g8-dotfiles/p6df-lattice`: p6df plugin for lattice
-- `p6m7g8-dotfiles/p6df-linkedin`: p6df plugin for linkedin
-- `p6m7g8-dotfiles/p6df-loom`: p6df plugin for loom
-- `p6m7g8-dotfiles/p6df-m365`: p6df plugin for m365
-- `p6m7g8-dotfiles/p6df-miro`: p6df plugin for miro
-- `p6m7g8-dotfiles/p6df-okta`: p6df plugin for okta
-- `p6m7g8-dotfiles/p6df-oneschema`: p6df plugin for oneschema
-- `p6m7g8-dotfiles/p6df-rippling`: p6df plugin for rippling
-- `p6m7g8-dotfiles/p6df-slack`: p6df plugin for slack
-- `p6m7g8-dotfiles/p6df-zoom`: p6df plugin for zoom
+- `p6m7g8-dotfiles/p6df-jira`: p6df plugin for Jira
+- `p6m7g8-dotfiles/p6df-lattice`: p6df plugin for Lattice
+- `p6m7g8-dotfiles/p6df-linkedin`: p6df plugin for LinkedIn
+- `p6m7g8-dotfiles/p6df-loom`: p6df plugin for Loom
+- `p6m7g8-dotfiles/p6df-m365`: p6df plugin for Microsoft 365
+- `p6m7g8-dotfiles/p6df-miro`: p6df plugin for Miro
+- `p6m7g8-dotfiles/p6df-oneschema`: p6df plugin for OneSchema
+- `p6m7g8-dotfiles/p6df-pagerduty`: p6df plugin for PagerDuty
+- `p6m7g8-dotfiles/p6df-rippling`: p6df plugin for Rippling
+- `p6m7g8-dotfiles/p6df-slack`: p6df plugin for Slack
+- `p6m7g8-dotfiles/p6df-statuspage`: p6df plugin for Statuspage
+- `p6m7g8-dotfiles/p6df-zoom`: p6df plugin for Zoom
 
 ### System & Shell
-- `p6m7g8-dotfiles/p6df-core`: p6df plugin for core
-- `p6m7g8-dotfiles/p6df-darwin`: p6df plugin for darwin
-- `p6m7g8-dotfiles/p6df-macosx`: p6df plugin for macosx
+- `p6m7g8-dotfiles/p6df-darwin`: p6df plugin for macOS (Darwin)
+- `p6m7g8-dotfiles/p6df-macosx`: p6df plugin for macOS
 - `p6m7g8-dotfiles/p6df-shell`: p6df plugin for shell
 - `p6m7g8-dotfiles/p6df-sudo`: p6df plugin for sudo
 - `p6m7g8-dotfiles/p6df-tmux`: p6df plugin for tmux
-- `p6m7g8-dotfiles/p6df-vim`: p6df plugin for vim
-- `p6m7g8-dotfiles/p6df-zsh`: p6df plugin for zsh
+- `p6m7g8-dotfiles/p6df-vim`: p6df plugin for Vim
+- `p6m7g8-dotfiles/p6df-zsh`: p6df plugin for Zsh


### PR DESCRIPTION
## Summary

- Split "Cloud & Infrastructure" into **Cloud Providers**, **Cloud Native & DevOps**, and **Security & Networking**
- Rename "AI & LLM Tooling" → **AI & Generative AI**
- Add missing repos: `p6df-claudecode`, `p6df-ghcopilot`, `p6huggingface`
- Fix `p6df-copilot` → `p6df-ghcopilot` (repo was renamed)
- Remove non-existent repos: `dotgithub`, `p6df-greenhouse`
- Promote `p6df-core` to **Framework Core** section
- Rename "Collaboration & Productivity" → **Collaboration & SaaS**
- Capitalize proper nouns in all descriptions

## Test plan
- [ ] Verify all linked repos exist in the org
- [ ] Verify no repos are missing from the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)